### PR TITLE
fixed wrong usage of String::Utf8Value

### DIFF
--- a/src/shm-buffer.cc
+++ b/src/shm-buffer.cc
@@ -65,13 +65,13 @@ NAN_METHOD(shmop_open) {
   }
 
   int key      = args[0]->Int32Value();
-  char *flags  = *(String::Utf8Value(args[1]->ToString()));
+  uint16_t flag  = **(String::Value(args[1]));
   int shmflg   = args[2]->Int32Value();
   int shmatflg = 0;
   int size     = 0;
   struct shmid_ds shm;
 
-  switch (flags[0])
+  switch (flag)
   {
     case 'a':
       shmatflg |= SHM_RDONLY;


### PR DESCRIPTION
It is not safe to keep an reference of `*String::Utf8Value`, as the `String::Utf8Value` object is created on stack and released after it is never accessable. So instead of keeping its memory address (which is actually pointing to an address on stack), we can copy its content to another place, which is safely used afterwards.